### PR TITLE
Refactor UI & Enhance Statistics/Controls for Moshi

### DIFF
--- a/Moshi/ContentView.swift
+++ b/Moshi/ContentView.swift
@@ -34,44 +34,47 @@ struct ContentView: View {
     @State var sendToSpeaker = false
     @Environment(DeviceStat.self) private var deviceStat
     @State private var displayStats = false
-
+    
+    // Currently available models
+    private let availableModels: [ModelSelect] = [.hibiki]
     var body: some View {
-        NavigationSplitView(
-            sidebar: {
-                VStack {
-                List {
-                    ForEach([ModelSelect.hibiki]) { modelType in
-                        NavigationLink(
-                            modelType.rawValue,
-                            destination: {
-                                ModelView(
-                                    model: $model, modelType: modelType, displayStats: $displayStats
+        Group {
+            if availableModels.count == 1 {
+                // Skip navigation if only one model
+                ModelView(
+                    model: $model,
+                    modelType: availableModels[0],
+                    displayStats: $displayStats
+                )
+            } else {
+                NavigationSplitView(
+                    sidebar: {
+                        VStack {
+                            ForEach(availableModels) { modelType in
+                                NavigationLink(
+                                    modelType.rawValue,
+                                    destination: {
+                                        ModelView(
+                                            model: $model,
+                                            modelType: modelType,
+                                            displayStats: $displayStats
+                                        )
+                                    }
                                 )
-                            })
-                    }
-                }
-                Toggle("speaker", isOn: $sendToSpeaker)
-                    .toggleStyle(.button)
-                    .padding()
-                    .onChange(of: sendToSpeaker) { newValue in
-                        if newValue {
-                            setDefaultToSpeaker()
-                        } else {
-                            setDefaultToStd()
+                            }
                         }
+                        .navigationTitle("Available Models")
+                        #if os(iOS)
+                            .navigationBarTitleDisplayMode(.inline)
+                        #endif
+                    },
+                    detail: {
+                        Text("Please choose a model type")
                     }
-                }
-                .navigationTitle("Available Models")
-                #if os(iOS)
-                    .navigationBarTitleDisplayMode(.inline)
-                #endif
-
-            },
-            detail: {
-                Text("Please choose a model type")
-            })
+                )
+            }
+        }
     }
-
 }
 
 #Preview {

--- a/Moshi/ContentView.swift
+++ b/Moshi/ContentView.swift
@@ -26,6 +26,24 @@ enum ModelSelect: String, CaseIterable, Identifiable {
     case helium
 
     var id: Self { return self }
+    
+    var name: String {
+        switch self {
+        case .hibiki:
+            return "Hibiki 1B"
+        default:
+            return rawValue.capitalized
+        }
+    }
+    
+    var description: String {
+        switch self {
+        case .hibiki:
+            return "A French to English simultaneous translation model designed for real-time speech translation."
+        default:
+            return ""
+        }
+    }
 }
 
 struct ContentView: View {
@@ -33,7 +51,6 @@ struct ContentView: View {
     @State var selectedModel: ModelSelect = .mimi
     @State var sendToSpeaker = false
     @Environment(DeviceStat.self) private var deviceStat
-    @State private var displayStats = false
     
     // Currently available models
     private let availableModels: [ModelSelect] = [.hibiki]
@@ -43,8 +60,7 @@ struct ContentView: View {
                 // Skip navigation if only one model
                 ModelView(
                     model: $model,
-                    modelType: availableModels[0],
-                    displayStats: $displayStats
+                    modelType: availableModels[0]
                 )
             } else {
                 NavigationSplitView(
@@ -56,8 +72,7 @@ struct ContentView: View {
                                     destination: {
                                         ModelView(
                                             model: $model,
-                                            modelType: modelType,
-                                            displayStats: $displayStats
+                                            modelType: modelType
                                         )
                                     }
                                 )

--- a/Moshi/DeviceStat.swift
+++ b/Moshi/DeviceStat.swift
@@ -1,13 +1,21 @@
 import Foundation
 import MLX
 
+enum ThermalState: String {
+    case nominal = "Nominal"
+    case fair = "Fair"
+    case serious = "Serious"
+    case critical = "Critical"
+    case unknown = "Unknown"
+}
+
 @Observable
 final class DeviceStat: @unchecked Sendable {
 
     @MainActor
     var gpuUsage = GPU.snapshot()
     @MainActor
-    var thermalState: ProcessInfo.ThermalState = .nominal
+    var thermalState: ThermalState = .nominal
 
     private let initialGPUSnapshot = GPU.snapshot()
     private var timer: Timer?
@@ -27,7 +35,18 @@ final class DeviceStat: @unchecked Sendable {
         let thermalState = ProcessInfo.processInfo.thermalState
         DispatchQueue.main.async { [weak self] in
             self?.gpuUsage = gpuSnapshotDelta
-            self?.thermalState = thermalState
+            switch thermalState {
+                case .nominal:
+                    self?.thermalState = .nominal
+                case .fair:
+                    self?.thermalState = .fair
+                case .serious:
+                    self?.thermalState = .serious
+                case .critical:
+                    self?.thermalState = .critical
+                default:
+                    self?.thermalState = .unknown
+            }
         }
     }
 

--- a/Moshi/ModelView.swift
+++ b/Moshi/ModelView.swift
@@ -269,7 +269,7 @@ struct CombinedStatsView: View {
     let summary: StatsSummary
     let deviceStat: DeviceStat
     @State private var currentPage = 0
-    @State private var isExpanded = false
+    @State private var isExpanded = true
     
     var body: some View {
         VStack(spacing: 0) {


### PR DESCRIPTION
I had some extra time on the train, so this PR attempts to improve the UI for Moshi. I'm normally a backend engineer (definitely not a designer), but I've been practicing Swift/SwiftUI lately, and I'm happy with the results I was able to achieve!

You're obviously welcome to close this PR if you're not interested in it, but I figured I would share it.

-----

This PR overhauls the Moshi app’s user interface and device/model monitoring, including:

- **Model Selection Improvements:**  
  - Adds custom display names and descriptions to the `ModelSelect` enum (e.g., “Hibiki 1B” with a detailed description).  
  - Streamlines navigation by bypassing the model-selection screen when only one model is available, like is the case now.

- **Refactored ModelView:**  
  - Splits the view into distinct sections for status, output, and controls.  
  - Implements a collapsible, tabbed “CombinedStatsView” to display both device and model statistics. 
  - Adds a settings gear button that reveals a popover (including an external speaker toggle, which I think is more clearly labeled now).  

<img src="https://github.com/user-attachments/assets/049a2274-5bfc-4647-8f48-96c79e5f08ea" height=500>
<img src="https://github.com/user-attachments/assets/e2dfefc7-664d-4c13-a392-f8e945029111" height=500>
<img src="https://github.com/user-attachments/assets/58e0c540-aa71-4020-b5f1-655085cda9f8" height=500>
<img src="https://github.com/user-attachments/assets/ee952d37-7933-495f-bf20-3fb0747e2565" height=200>


-----

CLA statement:

I, coder543, confirm that I have read and understood the terms of the CLA of Kyutai-labs, as outlined in the repository's CONTRIBUTING.md, and I agree to be bound by these terms.

